### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -6,80 +6,116 @@
 
 UI for exposing the zip archives for automated content/concept export.
 
+## Code
+
+upp-exports
+
 ## Primary URL
+
 https://upp-exports.ft.com/
 
 ## Service Tier
+
 Bronze
 
 ## Lifecycle Stage
+
 Production
 
-## Delivered By
-content
-
-## Supported By
-content
-
-## Known About By
-
-- dimitar.terziev
-- hristo.georgiev
-- georgi.ivanov
-
 ## Host Platform
+
 Heroku
 
 ## Architecture
+
 The application is a simple [express](https://expressjs.com/) server pulling the content of a specific s3 bucket and visualizing it in a static html page. Each file listed in the page is than available to download from the user. The application is considered healthy if access to the s3 bucket can be performed. The node server is started with [pm2](https://pm2.keymetrics.io/) with a default memory limit of 1G. If an unhandled exception occur and the node process is terminated it will be automatically restarted by `pm2`.
 
 ## Contains Personal Data
+
 No
 
 ## Contains Sensitive Data
+
 No
 
-## Dependencies
-- okta
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
+
 None
 
 ## Failover Process Type
+
 None
 
 ## Failback Process Type
+
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Failover Details
+Enter descriptive text satisfying the following:
+The actions required to fail this system from one region to another. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Data Recovery Process Type
+
 NotApplicable
 
 ## Data Recovery Details
+
 The service does not store data, so it does not require any data recovery steps.
 
 ## Release Process Type
+
 FullyAutomated
 
 ## Rollback Process Type
+
 FullyAutomated
 
 ## Release Details
+
 The application is automatically deployed to Heroku upon commit in the `mater` branch of the repository. Hence the rollback process will require revert commit in order to restore to a previous state of the application.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
+
 Manual
 
 ## Key Management Details
+
 Once the key is the AWS account are rotated the new keys has to be added as configuration variables in Heroku.
 
 ## Monitoring
+
 <p>Healthcheck:&nbsp;&nbsp;<a href="https://upp-exports.ft.com/__health" style="background-color: rgb(255, 255, 255);">https://upp-exports.ft.com/__health</a><br></p>
 
-## Healthchecks
-- upp-exports-https
-
 ## First Line Troubleshooting
+
 <p><a href="https://dashboard.heroku.com/apps/upp-exports" target="_blank" style="background-color: rgb(255, 255, 255);">Heroku link</a><br></p><p><span style="font-weight: 700;">Issue:&nbsp;service is unable to connect to AWS S3</span></p><ul><li>check that AWS credentials are correctly&nbsp;configured in Heroku&nbsp;</li></ul>
 
 ## Second Line Troubleshooting
+
 Please contact the team via a message in the #upp-prod-incidents slack channel.


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/content-archives-web/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **upp-exports** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **upp-exports** system in [Biz Ops](https://biz-ops.in.ft.com/System/upp-exports).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
